### PR TITLE
Can now add user as instructor and create course w/o uuid

### DIFF
--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -15,7 +15,7 @@ exports.addCourse = async (req, res) => {
    };
 
    try {
-       await course.pushCourseToFirebase(bodyParams);
+       await course.pushCourseToFirebase(bodyParams, req.user);
        res.status(200).send(`Added course ${bodyParams.name}`)
    } catch (e) {
        res.status(410).json({

--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -6,17 +6,17 @@ const { db } = require("../shared/firebase")
 exports.addCourse = async (req, res) => {
    // Check that required data is given
    const bodyParams = req.body;
-   if (!("name" in bodyParams || "term" in bodyParams || "uuid" in bodyParams)) {
+   if (!("name" in bodyParams || "term" in bodyParams)) {
        res.status(422).json({
            status: 422,
-           error: "Missing one of the following parameters: name, term, or uuid"
+           error: "Missing one of the following parameters: name or term"
        });
        return;
    };
 
    try {
        await course.pushCourseToFirebase(bodyParams);
-       res.status(200).send(`Added course ${bodyParams.uuid}`)
+       res.status(200).send(`Added course ${bodyParams.name}`)
    } catch (e) {
        res.status(410).json({
            status: 410,

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -97,10 +97,12 @@ exports.updateUser = async (req, res) => {
     };
 };
 
-// DEFAULTS TO ADDING USER AS A STUDENT
+// DEFAULTS TO ADDING USER AS A STUDENT if field is there, add user as instructor
 exports.addUserToCourse = async (req, res) => {
     const courseUUID = req.params.courseId;
+    const bodyParams = req.body;
     let userObj = req.user;
+
     if (!courseUUID || !userObj) {
         res.status(422).json({
             status: 422,

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -97,7 +97,7 @@ exports.updateUser = async (req, res) => {
     };
 };
 
-// DEFAULTS TO ADDING USER AS A STUDENT if field is there, add user as instructor
+// Defaults to adding as a student. If req body contains "type" : "instructor", adds user as instructor
 exports.addUserToCourse = async (req, res) => {
     const courseUUID = req.params.courseId;
     const bodyParams = req.body;
@@ -111,13 +111,18 @@ exports.addUserToCourse = async (req, res) => {
         return;
     };
 
-
-    // Adds the user to the course as a student. If fails, responds with an error. Only works with users we've manually made
     try {
         let courseObj = await course.getCourseById(courseUUID);
-        await courseObj.addStudent(userObj.getUUID());
-        await userObj.addStudentCourse(courseObj.getUUID());
-        res.status(200).send(courseObj.getUUID());
+
+        if ("type" in bodyParams && bodyParams["type"] == "instructor") {
+            await courseObj.addInstructor(userObj.getUUID());
+            await userObj.addInstructorCourse(courseObj.getUUID());
+            res.status(200).send("Added user as instructor to course " + courseObj.getUUID());
+        } else {
+            await courseObj.addStudent(userObj.getUUID());
+            await userObj.addStudentCourse(courseObj.getUUID());
+            res.status(200).send("Added user as student to course " + courseObj.getUUID());
+        }
     } catch (e) {
         res.status(410).json({
             status: 410,

--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -119,23 +119,20 @@ class Course {
 }
 
 module.exports.pushCourseToFirebase = (updateParams) => {
-    // Consistent with User.js
-    const name = updateParams['name'];
-    const term = updateParams['term'];
-    const uuid = updateParams['uuid'];
     return new Promise(async (resolve, reject) => {
         try {
             // TODO: Implement logic for these lists later.
-            await db.ref("Courses").child(uuid).set({
-                name: name, 
-                term: term, 
-                uuid: uuid, 
-                studentList: ["dummy_user_id"], 
+            const courseRef = db.ref("Courses").push();
+            await courseRef.set({
+                name: updateParams['name'], 
+                term: updateParams['term'], 
+                uuid: (await courseRef).key, 
+                studentList: ["dummy_user_id"],     // Do we want to change these from dummy values?
                 instructorList: ["dummy_user_id"],
                 tagList: ["dummy_tag_id"],
                 postList: ["dummy_post_id"],
             });
-            resolve("Everything worked");
+            resolve((await courseRef).key);
         } catch(e) {
             console.log("There was an error: " + e);
             reject("Something went wrong");

--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -118,21 +118,26 @@ class Course {
     } 
 }
 
-module.exports.pushCourseToFirebase = (updateParams, user) => {
+module.exports.pushCourseToFirebase = (updateParams, user, courseUUID) => {
     return new Promise(async (resolve, reject) => {
         try {
-            // TODO: Implement logic for these lists later.
-            const courseRef = db.ref("Courses").push();
-            await courseRef.set({
-                name: updateParams['name'], 
-                term: updateParams['term'], 
-                uuid: (await courseRef).key, 
-                studentList: [],     // Do we want to change these from dummy values?
-                instructorList: [user.uuid],
-                tagList: [],
-                postList: [],
-            });
-            resolve((await courseRef).key);
+            if (courseUUID) {
+                await db.ref("Courses").child(courseUUID).set(updateParams);
+                resolve(courseUUID);
+            } else {
+                // TODO: Implement logic for these lists later.
+                const courseRef = db.ref("Courses").push();
+                await courseRef.set({
+                    name: updateParams['name'], 
+                    term: updateParams['term'], 
+                    uuid: (await courseRef).key, 
+                    studentList: [],     // Do we want to change these from dummy values?
+                    instructorList: [user.uuid],
+                    tagList: [],
+                    postList: [],
+                });
+                resolve((await courseRef).key);
+            }
         } catch(e) {
             console.log("There was an error: " + e);
             reject("Something went wrong");

--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -118,7 +118,7 @@ class Course {
     } 
 }
 
-module.exports.pushCourseToFirebase = (updateParams) => {
+module.exports.pushCourseToFirebase = (updateParams, user) => {
     return new Promise(async (resolve, reject) => {
         try {
             // TODO: Implement logic for these lists later.
@@ -127,10 +127,10 @@ module.exports.pushCourseToFirebase = (updateParams) => {
                 name: updateParams['name'], 
                 term: updateParams['term'], 
                 uuid: (await courseRef).key, 
-                studentList: ["dummy_user_id"],     // Do we want to change these from dummy values?
-                instructorList: ["dummy_user_id"],
-                tagList: ["dummy_tag_id"],
-                postList: ["dummy_post_id"],
+                studentList: [],     // Do we want to change these from dummy values?
+                instructorList: [user.uuid],
+                tagList: [],
+                postList: [],
             });
             resolve((await courseRef).key);
         } catch(e) {

--- a/backend/routes/api/user.js
+++ b/backend/routes/api/user.js
@@ -10,7 +10,7 @@ router.route("/")
     .delete(userController.deleteUser) // Delete
 
 // Matches with "/api/user/courseId"
-router.route("/:courseId")   // regex? how do we format the courseID
+router.route("/:courseId")
     .post(userController.addUserToCourse)
     .get(userController.getUserType)
 module.exports = router;

--- a/backend/test/courseTest.js
+++ b/backend/test/courseTest.js
@@ -30,9 +30,8 @@ describe('course', () => {
         }
 
         try {
-            const result = await course.pushCourseToFirebase(courseParams);
-            expect(result).to.equal("Everything worked");
-            //expect(1).to.equal(1);
+            const result = await course.pushCourseToFirebase(courseParams, { uuid: "fakeUser"}, courseParams.uuid);
+            expect(result).to.equal(courseParams.uuid);
         } catch(e) {
             console.log(e);
         }  


### PR DESCRIPTION
Modified user/courseId post route to accept the optional req body `"type" : "instructor"`, which will add the user as an instructor. Otherwise it defaults to adding as a student

Also changed the Course model to reflect the Tag model and set the uuid as the Firebase generated id. Removed uuid as a requirement in the course/ post route